### PR TITLE
Fix generate command

### DIFF
--- a/src/sliver/client.py
+++ b/src/sliver/client.py
@@ -522,7 +522,7 @@ class SliverClient(BaseClient):
         :rtype: client_pb2.Generate
         '''        
         req = client_pb2.GenerateReq()
-        req.ImplantConfig = config
+        req.Config.CopyFrom(config)
         return (await self._stub.Generate(req, timeout=timeout))
 
     async def regenerate(self, implant_name: str, timeout=TIMEOUT) -> client_pb2.Generate:


### PR DESCRIPTION
Prior to this patch the following code
```
    c2 = client_pb2.ImplantC2(URL="mtls://localhost:4444")
    mtls_config = client_pb2.ImplantConfig(GOOS="linux", GOARCH="amd64", ObfuscateSymbols=True, C2=[c2], Format=client_pb2.OutputFormat.Value("EXECUTABLE"))
    res = await client.generate(mtls_config)
```

would generate this error
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/james/projects/sliverpy/test.py", line 29, in main
    res = await client.generate(mtls_config)
  File "/var/data/python/lib/python3.9/site-packages/sliver/client.py", line 525, in generate
    req.ImplantConfig = config
AttributeError: 'GenerateReq' object has no attribute 'ImplantConfig'
```

I don't see an ImplantConfig in the protobuf https://github.com/BishopFox/sliver/blob/master/protobuf/clientpb/client.proto#L350-L352