### PR TITLE
Migrate and getsystem parameter fix

### DIFF
--- a/src/sliver/interactive.py
+++ b/src/sliver/interactive.py
@@ -261,7 +261,7 @@ class BaseInteractiveCommands(object):
         """
         system = client_pb2.GetSystemReq()
         system.HostingProcess = hosting_process
-        system.Config = config
+        system.Config.CopyFrom(config)
         return await self._stub.GetSystem(self._request(system), timeout=self.timeout)
 
     async def execute_shellcode(
@@ -422,7 +422,7 @@ class BaseInteractiveCommands(object):
         """
         migrate = client_pb2.MigrateReq()
         migrate.Pid = pid
-        migrate.Config = config
+        migrate.Config.CopyFrom(config)
         return await self._stub.Migrate(self._request(migrate), timeout=self.timeout)
 
     async def execute(


### PR DESCRIPTION
Fixes error that occurs when using the `migrate` and `getsystem`. It seems that it is required to use `CopyFrom` instead of assignment when using protobuf objects into requests.

Tested both commands, and they seem to work with this fix.

Example of the error that is raised when using assignment:
```
<class 'clientpb.client_pb2.ImplantConfig'>
Traceback (most recent call last):
  File "test-sliver.py", line 36, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "test-sliver.py", line 25, in main
    result = await session.get_system("spoolsv.exe", implantConfig)
  File "/mnt/c/Users/admin/Documents/work/venv-plugin-dev/lib/python3.8/site-packages/sliver/interactive.py", line 264, in get_system
    system.Config = config
AttributeError: Assignment not allowed to field "Config" in protocol message object.
```