### PR TITLE
generate tun_ip if none is provided

### DIFF
--- a/src/sliver/client.py
+++ b/src/sliver/client.py
@@ -416,6 +416,8 @@ class SliverClient(BaseClient):
 
         :param tun_ip: Virtual TUN IP listen address
         :type tun_ip: str
+        :type host: str
+        :param port: TCP port number to start listener on
         :param port: UDP port to start listener on
         :type port: int
         :param n_port: Virtual TUN port number
@@ -429,6 +431,10 @@ class SliverClient(BaseClient):
         :return: Protobuf WGListener object
         :rtype: client_pb2.WGListener
         """
+        if tun_ip is None:
+            uniq_ip = await self.generate_wg_ip()
+            tun_ip = uniq_ip.IP
+
         wg_req = client_pb2.WGListenerReq(
             TunIP=tun_ip,
             Host=host,


### PR DESCRIPTION
My bad, the gRPC call does not generate this, so this seems a good place to do it if necessary

Could do similar on implant generation, that's also done under the hood in the CLI but will break everything if omitted from a wg implant build. Happy to add that to this PR if you'd like.